### PR TITLE
EONEXT-48 - Added hint information block for zero results.

### DIFF
--- a/src/apps/search-result/no-results.scss
+++ b/src/apps/search-result/no-results.scss
@@ -1,0 +1,21 @@
+.content-list-page {
+  &--help {
+    padding-left: 16px;
+  }
+
+  &--help-title {
+    font-family: "Lora", serif;
+    font-size: 24px;
+    line-height: 1.5rem;
+    color: #252525;
+    margin-bottom: 0;
+  }
+
+  &--help-description {
+    font-family: "Lora", serif;
+    font-size: 16px;
+    line-height: 2.75rem;
+    color: #262626;
+    margin-bottom: 20px;
+  }
+}

--- a/src/apps/search-result/search-result-zero-hits.tsx
+++ b/src/apps/search-result/search-result-zero-hits.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FC } from "react";
 import { useText } from "../../core/utils/text";
+import "./no-results.scss";
 
 export interface SearchResultZeroHitsProps {
   dataCy?: string;
@@ -10,6 +11,15 @@ const SearchResultZeroHits: FC<SearchResultZeroHitsProps> = ({
   dataCy = "search-result-zero-hits"
 }) => {
   const t = useText();
+  const searchAppElement = document.querySelector(
+    '[data-dpl-app="search-result"]'
+  );
+  const noResultsHeading =
+    searchAppElement?.getAttribute("data-no-results-heading") || "";
+  const noResultsText =
+    searchAppElement?.getAttribute("data-no-results-text") || "";
+  const noResultsEnabled =
+    searchAppElement?.getAttribute("data-no-results-enabled") === "true";
 
   return (
     <div className="content-list-page" data-cy={dataCy}>
@@ -19,6 +29,12 @@ const SearchResultZeroHits: FC<SearchResultZeroHitsProps> = ({
       >
         {t("noSearchResultText")}
       </h1>
+      {noResultsEnabled && (
+        <div className="content-list-page--help">
+          <h2 className="content-list-page--help-title">{noResultsHeading}</h2>
+          <p className="content-list-page--help-description">{noResultsText}</p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EONEXT-48

#### Description

Added hint information block for zero results.

#### Screenshot of the result

<img width="1364" alt="Screenshot at Sep 12 19-10-04" src="https://github.com/user-attachments/assets/9cf586ce-51d6-47ff-ad67-62d6193e4a6f">


#### Additional comments or questions

...
