### PR TITLE
EONEXT-71 - Fixed stiles for translations for tablets screen.

### DIFF
--- a/src/apps/menu/translations/header-styles-extended.scss
+++ b/src/apps/menu/translations/header-styles-extended.scss
@@ -16,10 +16,10 @@
   }
 
   &__translations-button {
-    line-height: 1.1;
+    line-height: 1.2;
     text-align: center;
     align-self: flex-end;
-    padding-bottom: 5px;
+    padding-bottom: 4px;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -57,9 +57,23 @@
   }
 }
 
+@media(max-width: 1024px) {
+  .header__translations-icon {
+    margin-bottom: 3px;
+  }
+
+  .header__translations-button {
+    padding-bottom: 6px;
+  }
+}
+
 @media(max-width: 768px) {
   .header__translations-label {
     display: none;
+  }
+
+  .header__translations-icon {
+    margin-bottom: 6px;
   }
 
   .header__translations-button {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EONEXT-71

#### Description

Aligned translations for tablets screens.

#### Screenshot of the result

IPAD 10 VERTICAL
<img width="1239" alt="Screenshot at Dec 02 14-01-55" src="https://github.com/user-attachments/assets/212cd5d3-713c-477a-9c5c-a795092248a6">

IPAD 10 HORIZONTAL
<img width="1402" alt="Screenshot at Dec 02 14-01-16" src="https://github.com/user-attachments/assets/93592f94-57cd-4999-993d-d18921edea98">

IPAD 9 VERTICAL
<img width="1286" alt="Screenshot at Dec 02 13-59-30" src="https://github.com/user-attachments/assets/62944204-25b9-4cef-80fb-f03340abf02d">

IPAD 9 HORIZONTAL
<img width="1389" alt="Screenshot at Dec 02 14-00-00" src="https://github.com/user-attachments/assets/21cdef8e-eec2-488e-8585-54c950b0dd49">

BROWSER ON THE SAME WIDTH
<img width="994" alt="Screenshot at Dec 02 14-02-32" src="https://github.com/user-attachments/assets/8ba62d7b-7f28-4ce8-a58c-bdb63707726b">

#### Additional comments or questions

---
