### PR TITLE
EONEXT-116 - Forcing the library token usage when user is logged for LMS API.

### DIFF
--- a/src/core/dbc-gateway/graphql-fetcher.ts
+++ b/src/core/dbc-gateway/graphql-fetcher.ts
@@ -4,6 +4,7 @@ import { getToken, TOKEN_LIBRARY_KEY, TOKEN_USER_KEY } from "../token";
 import DbcGateWayHttpError from "./DbcGateWayHttpError";
 import { getQueryUrlFromContext } from "./helper";
 
+const forceLibraryToken = document.querySelector("[data-lms-user-api-enabled]")?.getAttribute("data-lms-user-api-enabled") === "true";
 export const fetcher = <TData, TVariables>(
   query: string,
   variables?: TVariables
@@ -14,7 +15,9 @@ export const fetcher = <TData, TVariables>(
 
     // The whole concept of agency id, profile and and bearer token needs to be refined.
     // First version is with a library token.
-    const token = getToken(TOKEN_USER_KEY) || getToken(TOKEN_LIBRARY_KEY);
+    let token = getToken(TOKEN_LIBRARY_KEY);
+    if (forceLibraryToken !== true)
+      token = getToken(TOKEN_USER_KEY) || token;
 
     const headers = {
       "Content-Type": "application/json"


### PR DESCRIPTION
https://inlead.atlassian.net/browse/EONEXT-116?focusedCommentId=86275