### PR TITLE
EONEXT-95 - Fix for hide the empty custom description fields.

### DIFF
--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -36,7 +36,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work, customF
       return {
         label: fieldData.label,
         options: fieldData.options,
-        tags: values.map((tag: string) => {
+        tags: values.filter(Boolean).map((tag: string) => {
           return {
             term: tag,
             url: new URL(fieldData.options.url.replace(/\$\{\s*tag\s*\}/ig, tag), window.location.href)


### PR DESCRIPTION
Fixed the display of the custom description empty fields.