### PR TITLE
EONEXT-144 - Hide additional material description header when there no body.

### DIFF
--- a/src/components/material/MaterialAdditionalDescription.tsx
+++ b/src/components/material/MaterialAdditionalDescription.tsx
@@ -36,14 +36,16 @@ const MaterialAdditionalDescription: React.FC<MaterialAdditionalDescriptionProps
 
   return (
     <section className="material-description">
-      <h2 className="text-header-h4 pb-24">
-        {t(data.label)}
-      </h2>
-
       {data.body && (
-        <p className="text-body-large material-description__content">
-          {data.body}
-        </p>
+        <>
+          <h2 className="text-header-h4 pb-24">
+            {t(data.label)}
+          </h2>
+
+          <p className="text-body-large material-description__content">
+            {data.body}
+          </p>
+        </>
       )}
 
       <div className="material-description__links mt-32">


### PR DESCRIPTION
https://inlead.atlassian.net/browse/EONEXT-144?focusedCommentId=87416