### PR TITLE
EONEXT-193 - Fix for search filters that use the 'filter.key' values.

### DIFF
--- a/src/apps/search-result/useFilterHandler.tsx
+++ b/src/apps/search-result/useFilterHandler.tsx
@@ -103,7 +103,7 @@ const useFilterHandler = () => {
       // We dont have a traceId, so we just use a placeholder.
       addToFilter({
         facet: mapFacetToFilter(facet),
-        term: { key: "key", term: urlFilter, traceId: "traceId" },
+        term: { key: urlFilter, term: urlFilter, traceId: "traceId" },
         origin: "facetUrl"
       });
     }


### PR DESCRIPTION
https://inlead.atlassian.net/browse/EONEXT-193

Works view page: When you click on author, subject or subject number on the works view page, a star search is performed with the specific filter.

See https://docs.google.com/spreadsheets/d/1qct35COcbozmMWj6XttDZMKB5Zw0HLyXfQ3yHlMYTfI/edit?gid=795268594#gid=795268594, line 94.