### PR TITLE
EONEXT-193 - Fix for duplication of the dk5 tag at the material description.

### DIFF
--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -99,13 +99,6 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work, customF
     : [];
 
   let knownFileds: any = {
-    [t("subjectNumberText")]: !isFiction && dk5MainEntry ? {
-      label: t("subjectNumberText"),
-      tags: [{
-        url: constructSearchUrl(searchUrl, dk5MainEntry.display),
-        term: dk5MainEntry.display
-      }]
-    } : null,
     [t("inSameSeriesText")]: {
       label: t("inSameSeriesText"),
       tags: seriesMembersList,


### PR DESCRIPTION
https://inlead.atlassian.net/browse/EONEXT-193

<img width="692" height="442" alt="image" src="https://github.com/user-attachments/assets/ea359f4b-4916-4940-99ef-c104a30177a0" />
